### PR TITLE
Add MIME mappings for fonts

### DIFF
--- a/manifest.dnn
+++ b/manifest.dnn
@@ -19,7 +19,7 @@
           <skinFiles>
             <basePath>Portals\_default\Skins\nvQuickTheme\</basePath>
             <skinName>nvQuickTheme</skinName>
-            
+
             <!-- Main Directory -->
             <skinFile>
               <path />
@@ -33,40 +33,71 @@
               <path />
               <name>LICENSE</name>
             </skinFile>
-                        
+
           </skinFiles>
         </component>
-        
+
         <!-- Menus, Partials, and Root -->
         <component type="ResourceFile">
           <resourceFiles>
             <basePath>Portals\_default\Skins\nvQuickTheme\</basePath>
             <resourceFile>
-                <name>else.zip</name>
+              <name>else.zip</name>
             </resourceFile>
           </resourceFiles>
         </component>
-        
+
         <!-- CSS, Fonts, JS, Images Folder -->
         <component type="ResourceFile">
           <resourceFiles>
             <basePath>Portals\_default\Skins\nvQuickTheme\</basePath>
             <resourceFile>
-                <name>dist.zip</name>
+              <name>dist.zip</name>
             </resourceFile>
           </resourceFiles>
         </component>
-        
+
         <!-- Containers Folder -->
         <component type="ResourceFile">
           <resourceFiles>
             <basePath>Portals\_default\Containers\nvQuickTheme\</basePath>
             <resourceFile>
-                <name>cont.zip</name>
+              <name>cont.zip</name>
             </resourceFile>
           </resourceFiles>
         </component>
-        
+
+        <!-- Ensure MIME types are mapped -->
+        <component type="Config">
+          <config>
+            <configFile>web.config</configFile>
+            <install>
+              <configuration>
+                <nodes configfile="web.config">
+                  <node path="/configuration/system.webServer" targetpath="/configuration/system.webServer/staticContent" action="update" collision="ignore">
+                    <staticContent>
+                    </staticContent>
+                  </node>
+                  <node path="/configuration/system.webServer/staticContent" action="update" key="fileExtension" collision="ignore">
+                    <remove fileExtension=".otf" />
+                    <mimeMap fileExtension=".otf" mimeType="font/otf" />
+                    <remove fileExtension=".svg" />
+                    <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
+                    <remove fileExtension=".woff" />
+                    <mimeMap fileExtension=".woff" mimeType="font/x-woff" />
+                    <remove fileExtension=".woff2" />
+                    <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+                  </node>
+                </nodes>
+              </configuration>
+            </install>
+            <uninstall>
+              <configuration>
+                <nodes />
+              </configuration>
+            </uninstall>
+          </config>
+        </component>
       </components>
     </package>
   </packages>


### PR DESCRIPTION
## Description
This ensures that the font files which are not mapped by default on older
versions of IIS will be mapped, so that IIS will serve them correctly
(otherwise it will return a 404).  This list is based on the default
mappings in IIS 7 (from https://support.microsoft.com/en-us/help/936496)
and the MIME types are the defaults from an IIS 10 installation.

These additions will override any system-wide defaults set (though they
should match the defaults present in newer servers).  These instructions
will _not_ overwrite any existing mappings in the `web.config` file for
the specific site into which the theme is installed (i.e. if `.woff` has
already been mapped in the site, this won't change that mapping, but if
`.woff2` has not been mapped, that mapping will be added).  Any other
customizations to the `staticContent` section of the `web.config` file
will also be preserved.

## Related to Issue
Fixes #60

## How Has This Been Tested?
Copied from a working theme

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
