### PR TITLE
Make action menu styling apply to the QuickSettings button

### DIFF
--- a/src/scss/components/_dnn.scss
+++ b/src/scss/components/_dnn.scss
@@ -3273,7 +3273,7 @@ div.actionMenu .dnn_mact {
   margin-left:-28px !important;
   margin-top:1px !important;
   
-  > li[class*="actionMenu"] {
+  > li[class*="action"] {
     width:auto !important;
     height:auto !important;
     float:none !important;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #72 

## Description
<!--- Describe your changes in detail -->
On an SPA module, the quicksettings button `class="actionQuickSettings"` so the `li[class*="actionMenu"]` selector doesn't pick it up. Changing to `li[class*="action"]` does the trick.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Changed selector. Tested in IE11, Firefox, Chrome.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/437224/47796096-8c26ab00-dd1b-11e8-88ac-2cd3b935aefc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
