### PR TITLE
Change font-display descriptor to fallback

### DIFF
--- a/src/scss/components/_fonts.scss
+++ b/src/scss/components/_fonts.scss
@@ -7,7 +7,7 @@
         url('../fonts/OpenSans-Regular.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
-    font-display: auto;
+    font-display: fallback;
 }
 
 @font-face {
@@ -19,7 +19,7 @@
         url('../fonts/OpenSans-Bold.ttf') format('truetype');
     font-weight: bold;
     font-style: normal;
-    font-display: auto;
+    font-display: fallback;
 }
 
 @font-face {
@@ -31,7 +31,7 @@
         url('../fonts/OpenSans-ExtraBold.ttf') format('truetype');
     font-weight: 800;
     font-style: normal;
-    font-display: auto;
+    font-display: fallback;
 }
 
 @font-face {
@@ -43,7 +43,7 @@
         url('../fonts/OpenSans-Light.ttf') format('truetype');
     font-weight: 300;
     font-style: normal;
-    font-display: auto;
+    font-display: fallback;
 }
 
 @font-face {
@@ -55,5 +55,5 @@
         url('../fonts/OpenSans-SemiBold.ttf') format('truetype');
     font-weight: 600;
     font-style: normal;
-    font-display: auto;
+    font-display: fallback;
 }


### PR DESCRIPTION
## Related to Issue
Fixes #93 

## Description
Changed font-display from "auto" to "fallback" to provide quick loading of a fallback font while web fonts are still loading.

## How Has This Been Tested?
Local dev.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
