### PR TITLE
Update version number in package.json to match the correct version of nvQuickTheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nvQuickTheme",
-  "version": "1.0.0",
+  "version": "1.3.0",
   "description": "Barebones Bootstrap 4 DNN Theme",
   "main": "gulpfile.js",
   "author": "nvisionative",

--- a/project-details.json
+++ b/project-details.json
@@ -1,6 +1,6 @@
 {
 	"project": "nvQuickTheme",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"author": "TK Sheppard &amp; David Poindexter",
 	"company": "nvisionative",
 	"url": "www.nvquicktheme.com",

--- a/yarn.lock
+++ b/yarn.lock
@@ -340,9 +340,9 @@ boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
 
-bootstrap@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
+bootstrap@4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.2.1.tgz#8f8bdca024dbf0e8644da32e918c8a03a90a5757"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
## Related to Issue
Fixes #65 

## Description
The version number in `package.json` reflects the version of the nvQuickTheme **tooling**.  The version number in `project-details.json` reflects the version of the output **theme** package.  

These version numbers should always be in sync within the repo.  However, for someone using nvQuickTheme to create their own custom theme, the version numbers should not be in sync, as they represent two different things, one for nvQuickTheme (the tool) and one for the custom theme output package.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
