### PR TITLE
Corrected missing src reference in the gulpfile.js for image compression

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,7 @@ var gulp          = require('gulp'),
     
 // Compresses images for production.
 gulp.task('images', function() {
-	return gulp.src( './images/**/*.{jpg,jpeg,png,gif}' )
+  return gulp.src( './'+src+'images/**/*.{jpg,jpeg,png,gif}' )
 		.pipe(imagemin({
       interlaced: true,
       progressive: true,


### PR DESCRIPTION
## Related to Issue
Fixes #67 

## Description
Updated incorrect path for image compression task in `gulpfile.js`.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
