### PR TITLE
Add gren configuration file for more granular control over auto-generation of release notes

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,30 @@
+module.exports = {
+    "dataSource": "issues",
+    "prefix": "",
+    "onlyMilestones": false,
+    "groupBy": {
+        "Bugs Fixed:": ["bug"],
+        "Closed (no labels):": ["closed"],
+        "Documentation Improvements:": ["documentation"],
+        "Duplicate Issues:": ["duplicate"],
+        "Enhancements:": ["enhancement"],
+        "Good First Issues:": ["good first issue"],
+        "Greenkeeper Updates:": ["greenkeeper"],
+        "Help Wanted:": ["help wanted"],
+        "Invalid Issues:": ["invalid"],
+        "On Hold Issues:": ["on hold"],
+        "Questions:": ["question"],
+        "Won't Fix:": ["wontfix"]
+    },
+    "changelogFilename": "CHANGELOG.md",
+    "template": {
+        commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
+        issue: "- [{{text}}]({{url}}) {{name}}",
+        label: "[**{{label}}**]",
+        noLabel: "closed",
+        group: "\n#### {{heading}}\n",
+        changelogTitle: "# Changelog\n\n",
+        release: "## {{release}} ({{date}})\n{{body}}",
+        releaseSeparator: "\n---\n\n"
+    }
+}


### PR DESCRIPTION
## Related to Issue
Resolves #105 

## Description
Add gren configuration file for more granular control over auto-generation of release notes.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
