### PR TITLE
Add support for theme Release Notes in manifest and package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -211,7 +211,7 @@ gulp.task('zipcontainers', function() {
 
 // Zips everything else
 gulp.task('zipelse', function() {
-  return gulp.src(['./menus/**/*', './partials/*', '*.{ascx,xml,html,htm}'], {base: '.'})
+  return gulp.src(['./menus/**/*', './partials/*', '*.{ascx,xml,html,htm,txt}'], {base: '.'})
     .pipe(gulp.dest('./'+temp))
     .pipe(replace('dist/', ''))
     .pipe(zip('else.zip'))

--- a/manifest.dnn
+++ b/manifest.dnn
@@ -11,6 +11,7 @@
         <email>support@nvisionative.com</email>
       </owner>
       <license src="LICENSE" />
+      <releaseNotes src="themeReleaseNotes.txt" />
       <dependencies>
         <dependency type="coreVersion">09.00.00</dependency>
       </dependencies>


### PR DESCRIPTION
## Related to Issue
Resolves #68 

## Description
Support has been added for release notes.  Release notes are displayed during the DNN theme installation process.  Follow is a list of changes required to add this feature.

- **manifest.dnn** has been updated to include the `<releaseNotes ... />` element.
- A **themeReleaseNotes.txt** file has been added to the project root and by default is empty.  It is up to the theme developer to determine if/how they would like to use this feature.
- The build process has been updated to include **txt** files in the theme install package.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
