### PR TITLE
Fixed white text color and dividers in the bootstrap jumbotron

### DIFF
--- a/src/scss/components/_banner.scss
+++ b/src/scss/components/_banner.scss
@@ -1,0 +1,7 @@
+.jumbotron {
+  color: #000;
+
+  hr {
+    background-color: #000;
+  }
+}

--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -4,3 +4,4 @@
 @import 'grid';
 @import 'helpers';
 @import 'nav';
+@import 'banner';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #134 

## Description
I added a new component called `_banner.scss` to hold banner specific styles. In this section I added specific code for the jumbotron to make sure the font color and `hr` background color is black. Otherwise the color defaults to white.

I am not sure if this is the best place for the code to live but wanted to share how I am solving this problem for my local instance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
