### PR TITLE
Fixes missing svg files in dist folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,7 +52,7 @@ var paths = {
     dest: './dist/js/'
   },
   images: {
-    src: './src/images/**/*.{jpg,jpeg,png,gif}',
+    src: './src/images/**/*.{jpg,jpeg,png,gif,svg}',
     dest: './dist/images/'
   },
   styles: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #140

## Description
Adds the svg extension to the image file types.

## How Has This Been Tested?
I put a mix of jpg and svg files in the src/images and they got properly minified and copied in the dist/images folder.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.