### PR TITLE
Added default login module

### DIFF
--- a/src/scss/components/_components.scss
+++ b/src/scss/components/_components.scss
@@ -1,4 +1,5 @@
 @import 'dnn';
+@import 'login';
 @import 'buttons';
 @import 'fonts';
 @import 'grid';

--- a/src/scss/components/_login.scss
+++ b/src/scss/components/_login.scss
@@ -1,0 +1,117 @@
+.dnnLogin {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+
+    > div {
+        width:100%;
+        padding:0;
+    }
+
+    .LoginPanel {
+        width: 100%;
+        padding: 0;
+
+        .dnnFormItem {
+            .dnnFormLabel {
+                display:none;
+            }
+            
+            &:nth-child(1), &:nth-child(2) {
+                display: flex;
+                flex-direction: column;
+
+                .dnnFormLabel {
+                    display: block;
+                    float:left;
+                    &::after {
+                        clear:both;
+                        content: '';
+                    }
+                }
+
+                label {
+                    font-weight: 700;
+                    font-size: 1.5rem;
+                }
+
+                input {
+                    min-width: 100%;
+                    font-size: 1.5rem;
+                    font-weight: 500;
+                    padding: .25em;
+                }
+            }
+
+            &:nth-child(3) {
+                width: 100%;
+                display: flex;
+                justify-content: center;
+                margin-top: .5em;
+
+                a {
+                    width: 50%;
+                    margin:0;
+
+                    &.dnnPrimaryAction {
+                        margin-right:.25em;
+                    }
+                    &.dnnSecondaryAction {
+                        margin-left:.25em;
+                    }
+                }
+            }
+
+            .dnnLoginRememberMe {
+                display: block;
+                margin: 1em 0;
+
+                img {
+                    margin: 0;
+                    padding: 0;
+                }
+
+                .dnnCheckbox {
+                    margin: 1em 0;
+                    display: inline-flex;
+                    vertical-align: middle;
+                }
+
+                label {
+                    margin-left: .5em;
+                    font-size: 1.25rem;
+                    font-weight: 550;
+                }
+            }
+
+            &:last-child {
+                width: 100%;
+
+                .dnnLoginActions {
+                    width: 100%;
+
+                    ul { 
+                        margin:0;
+                        padding:0;
+                    }
+                    li {
+                        width: 50%;
+                        margin: 0;
+
+                        &:nth-child(1) {
+                            padding-right: .25em;
+                        }
+
+                        &::nth-child(2) {
+                            padding-left: .25em;
+                        }
+                    }
+
+                    a {
+                        width: 100%;
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Related to Issue
Fixes #145

## Description
Adds Responsive Styles for all breakpoints for the login module. This attempts to create a similar look and feel across the different breakpoints. As well it attempts to take up all the space available in the container, which can make it really wide on some skins.

## How Has This Been Tested?
I have tested this on all breakpoints.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/17751436/55269205-5accef80-5267-11e9-9085-f2abe66dbfa8.png)

![image](https://user-images.githubusercontent.com/17751436/55269219-6ae4cf00-5267-11e9-9bbe-2d04f5d29c23.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Notes
I understand this may be something the team at @nvisionative may be working on. I was already building this for a theme and thought I would share my approach as well as my default nvQuickTheme login styles.