### PR TITLE
Import Bootstrap and include in SASS compilation, so variable names, mix-ins, etc can be used/extended

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,10 +44,6 @@ var paths = {
     src: './node_modules/normalize.css/normalize.css',
     dest: './dist/css/'
   },
-  bsCss: {
-    src: './node_modules/bootstrap/dist/css/bootstrap.min.*',
-    dest: './dist/css/'
-  },
   bsJs: {
     src: './node_modules/bootstrap/dist/js/bootstrap.bundle.min.*',
     dest: './dist/js/'
@@ -184,7 +180,7 @@ function images() {
 // Compile custom SCSS to CSS and copy to dist/css
 function styles() {
   return gulp.src(paths.styles.src, { sourcemaps: true })
-  .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
+  .pipe(sass({includePaths: ['./node_modules']},{outputStyle: 'compressed'}).on('error', sass.logError))
   .pipe(cleanCSS())
   .pipe(rename({suffix: '.min'}))
   .pipe(autoprefixer({browsers: ['last 2 versions', 'ie >= 9', '> 1%']}))
@@ -322,7 +318,7 @@ function watch() {
 }
 
 // gulp init
-var init = gulp.series(fontsInit, faFontsInit, faCssInit, slimMenuInit, normalizeInit, bsCssInit, bsJsInit);
+var init = gulp.series(fontsInit, faFontsInit, faCssInit, slimMenuInit, normalizeInit, bsJsInit);
 
 // gulp build
 var build = gulp.series(init, styles, scripts, images, containers, manifest);

--- a/partials/_includes.ascx
+++ b/partials/_includes.ascx
@@ -1,9 +1,8 @@
 <dnn:META ID="mobileScale" runat="server" Name="viewport" Content="width=device-width, initial-scale=1.0" />
 <dnn:DnnCssExclude runat="server" Name="dnndefault" /> 
 
-<dnn:DnnCssInclude runat="server" FilePath="dist/css/bootstrap.min.css" Priority="100" PathNameAlias="SkinPath" />
-<dnn:DnnCssInclude runat="server" FilePath="dist/css/all.min.css" Priority="110" PathNameAlias="SkinPath" />
-<dnn:DnnCssInclude runat="server" FilePath="dist/css/style.min.css" Priority="120" PathNameAlias="SkinPath" />
+<dnn:DnnCssInclude runat="server" FilePath="dist/css/all.min.css" Priority="100" PathNameAlias="SkinPath" />
+<dnn:DnnCssInclude runat="server" FilePath="dist/css/style.min.css" Priority="110" PathNameAlias="SkinPath" />
 
 <dnn:DnnJsInclude runat="server" FilePath="dist/js/jquery.slimmenu.min.js" ForceProvider="DnnFormBottomProvider" Priority="100" PathNameAlias="SkinPath" />
 <dnn:DnnJsInclude runat="server" FilePath="dist/js/bootstrap.bundle.min.js" ForceProvider="DnnFormBottomProvider" Priority="110" PathNameAlias="SkinPath" />

--- a/src/scss/autoload/_autoload.scss
+++ b/src/scss/autoload/_autoload.scss
@@ -1,0 +1,1 @@
+@import 'bootstrap';

--- a/src/scss/autoload/_bootstrap.scss
+++ b/src/scss/autoload/_bootstrap.scss
@@ -1,0 +1,1 @@
+@import 'bootstrap/scss/bootstrap';

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,3 +1,4 @@
+@import 'autoload/autoload';
 @import 'variables/variables';
 @import 'mixins/mixins';
 @import 'base';


### PR DESCRIPTION
## Related to Issue
Fixes #26 

## Description
Import Bootstrap and include in SASS compilation, so variable names, mix-ins, etc. can be used/extended.  Within the `/src/scss` folder there is now an `autoload` folder.  This folder is intended to include/import any 3rd party SASS that should be included within the SASS compilation.

`bootstrap.bundle.min.js` is still loaded directly from node_modules.

`gulpfile.js` has been updated to include node_modules within the sass paths.

`partials/_includes.ascx` has been updated to no longer load Bootstrap CSS separately, since it is now included within `style.min.css`.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
