### PR TITLE
Added "cleandist" gulp task and renamed "cleanup" to "cleantemp"

### DIFF
--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -12,7 +12,8 @@ This command initializes all third-party dependencies utilized within **nvQuickT
 * **gulp bsJsInit**
 
 ### gulp build
-This command error checks, concatenates, compiles and minifies all your JS and SCSS into the `./dist/` folder, as well as copies your containers to the correct folder. More specifically, it executes the following commands in series (completes each task before the next):
+This command cleans your `./dist/` folder, then error checks, concatenates, compiles and minifies all your JS and SCSS into the `./dist/` folder, as well as copies your containers to the correct folder. More specifically, it executes the following commands in series (completes each task before the next):
+* **gulp cleandist**
 * **gulp init**
 * **gulp styles**
 * **gulp scripts**
@@ -55,6 +56,9 @@ Copies containers to the correct folder within your DNN instance (assuming you a
 ## Process Commands
 These commands are used within other commands and for other special situations. _We recommend use of these only for advanced users._
 
+### gulp cleandist
+Deletes contents of `./dist/` folder. This is particularly useful when assets (such as images) are no longer required and removed from `./src/` folder. It is the first task triggered during **gulp build**.
+
 ### gulp zipdist
 ZIPs contents of `./dist/` folder. Used to prepare for theme packaging.
 
@@ -67,5 +71,5 @@ ZIPs contents of `./menus/` folder, `./partials/` folder, and all ASCX, XML, HTM
 ### gulp zippackage
 ZIPs all subset ZIP files and other pertinent project files into theme package installation file using the following naming convention: `[project]_[version]_install.zip`
 
-### gulp cleanup
-Deletes all temporary ZIP and project files used in package tasks.
+### gulp cleantemp
+Deletes all temporary ZIP and project files from `./temp/` folder used in package tasks.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -88,8 +88,11 @@ var paths = {
     zipfile: project+'\_'+version+'\_install.zip',
     dest: './build/'
   },
-  cleanup: {
+  cleantemp: {
     src: './temp/'
+  },
+  cleandist: {
+    src: './dist/'
   }
 };
     
@@ -244,6 +247,20 @@ function manifest() {
 
 
 /*------------------------------------------------------*/
+/* MAINTENANCE TASKS -----------------------------------*/
+/*------------------------------------------------------*/
+// Clean up dist folder
+function cleandist() {
+  return gulp.src(paths.cleandist.src, { allowEmpty: true })
+    .pipe(clean())
+    .pipe(notify({message: 'dist folder cleaned up!', title : 'cleandist', sound: false}));
+}
+/*------------------------------------------------------*/
+/* END MAINTENANCE TASKS -------------------------------*/
+/*------------------------------------------------------*/
+
+
+/*------------------------------------------------------*/
 /* PACKAGING TASKS -------------------------------------*/
 /*------------------------------------------------------*/
 // ZIP contents of dist folder
@@ -284,11 +301,11 @@ function zippackage() {
     .pipe(notify({message: '<%= file.relative %> created!', title : 'zippackage', sound: false}));
 }
 
-// Cleanup temp folder
-function cleanup() {
-  return gulp.src(paths.cleanup.src)
+// Clean temp folder
+function cleantemp() {
+  return gulp.src(paths.cleantemp.src)
     .pipe(clean())
-    .pipe(notify({message: 'temp folder cleaned up!', title : 'cleanup', sound: false}));
+    .pipe(notify({message: 'temp folder cleaned up!', title : 'cleantemp', sound: false}));
 }
 /*------------------------------------------------------*/
 /* END PACKAGING TASKS ---------------------------------*/
@@ -321,10 +338,10 @@ function watch() {
 var init = gulp.series(fontsInit, faFontsInit, faCssInit, slimMenuInit, normalizeInit, bsJsInit);
 
 // gulp build
-var build = gulp.series(init, styles, scripts, images, containers, manifest);
+var build = gulp.series(cleandist, init, styles, scripts, images, containers, manifest);
 
 // gulp package
-var package = gulp.series(build, ziptemp, zippackage, cleanup);
+var package = gulp.series(build, ziptemp, zippackage, cleantemp);
 /*------------------------------------------------------*/
 /* END DEV TASKS ---------------------------------------*/
 /*------------------------------------------------------*/
@@ -346,12 +363,13 @@ exports.styles = styles;
 exports.scripts = scripts;
 exports.containers = containers;
 exports.manifest = manifest;
+exports.cleandist = cleandist;
 exports.zipdist = zipdist;
 exports.zipcontainers = zipcontainers;
 exports.zipelse = zipelse;
 exports.ziptemp = ziptemp;
 exports.zippackage = zippackage;
-exports.cleanup = cleanup;
+exports.cleantemp = cleantemp;
 exports.serve = serve;
 exports.watch = watch;
 exports.init = init;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #176 

## Description
Added **gulp cleandist** tasks that cleans `./dist/` folder of all files. It is triggered as the first item during **gulp build**, but can be also called on its own.

Also, renamed existing **gulp cleanup** to **gulp cleantemp**, as when having two "clean" tasks, both names had to refer to their function in more detail.

## How Has This Been Tested?
Local dev environment

## Screenshots (if appropriate):
n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
