### PR TITLE
Add bootstrap overrides correctly

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,3 +1,4 @@
+@import 'variables/bs-overrides';
 @import 'autoload/autoload';
 @import 'variables/variables';
 @import 'mixins/mixins';

--- a/src/scss/variables/_bs-overrides.scss
+++ b/src/scss/variables/_bs-overrides.scss
@@ -1,0 +1,75 @@
+/* Bootstrap Overrides */
+
+// Bootstrap colors
+$bs-colors: (
+  'primary':#ec3d46,
+  'secondary':#00a5e1,
+  'success':#28a745,
+  'info':#17a2b8,
+  'warning':#ffc107,
+  'danger':#dc3545,
+  'light':#f8f9fa,
+  'dark':#343a40
+);
+
+$primary:map-get($bs-colors, 'primary');
+$secondary:map-get($bs-colors, 'secondary');
+$success:map-get($bs-colors, 'success');
+$info:map-get($bs-colors, 'info');
+$warning:map-get($bs-colors, 'warning');
+$danger:map-get($bs-colors, 'danger');
+$light:map-get($bs-colors, 'light');
+$dark:map-get($bs-colors, 'dark');
+
+// Grid breakpoints (changed to relative units to fix cross-platform inconsistencies)
+$grid-breakpoints: (
+  xs: 0,
+  sm: 36rem,
+  md: 48rem,
+  lg: 62rem,
+  xl: 75rem
+);
+
+// Grid containers (changed to relative units to fix cross-platform inconsistencies)
+$container-max-widths: (
+  sm: 33.75rem,
+  md: 45rem,
+  lg: 60rem,
+  xl: 71.25rem
+);
+
+// Override Bootstrap spacers for more options
+$spacer:1rem;
+$spacers: (
+    0: 0,
+    1: $spacer,
+    2: ($spacer * 2),
+    3: ($spacer * 3),
+    4: ($spacer * 4),
+    5: ($spacer * 5),
+    6: ($spacer * 6),
+    7: ($spacer * 7),
+    8: ($spacer * 8)
+);
+
+// Get rid of deprecated warnings
+$enable-deprecation-messages: false;
+
+// Change gutter width
+$grid-gutter-width: 22px !default;
+
+// Form Control changes
+$input-height:2rem;
+$input-color:#444;
+$input-font-size:13;
+$input-border-radius:2px;
+$input-padding-y:.25rem;
+$input-padding-x:.75rem;
+
+$form-check-input-margin-y:3px;
+
+$custom-file-height-inner:unset;
+$custom-file-line-height:1.61539;
+
+// The yiq lightness value that determines when the lightness of color changes from "dark" to "light". Acceptable values are between 0 and 255.
+// $yiq-contrasted-threshold:  195 !default;

--- a/src/scss/variables/_colors.scss
+++ b/src/scss/variables/_colors.scss
@@ -3,9 +3,9 @@ $light-grey: #e6e6e6 !default;
 $grey:#7d7d7d !default;
 $dark-grey: #333333 !default;
 
-$primary-color: rgb(236, 61, 70) !default;
-$secondary-color: rgb(0, 165, 225) !default;
-$tertiary-color: rgb(70, 42, 43) !default;
+$primary-color: map-get($bs-colors, 'primary') !default;
+$secondary-color: map-get($bs-colors, 'secondary')  !default;
+$tertiary-color: #462a2b !default;
 
 $border-color: #bbb !default;
 $link-color: $primary-color !default;


### PR DESCRIPTION
## Related to Issue
Resolves #190 

## Description
Now there is a clear place to properly override bootstrap variables in `src/scss/variables/_bs-overrides.scss`.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
