### PR TITLE
Correct unexpected unknown pseudo-element selector '::nth-child'

### DIFF
--- a/src/scss/components/_login.scss
+++ b/src/scss/components/_login.scss
@@ -102,7 +102,7 @@
                             padding-right: .25em;
                         }
 
-                        &::nth-child(2) {
+                        &:nth-child(2) {
                             padding-left: .25em;
                         }
                     }


### PR DESCRIPTION
## Related to Issue
Resolves #215 

## Description
Correct unexpected unknown pseudo-element selector '::nth-child'

## How Has This Been Tested?
Local dev environment.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
