### PR TITLE
Resolve popUpSkin load error

### DIFF
--- a/partials/_registers-popUpSkin.ascx
+++ b/partials/_registers-popUpSkin.ascx
@@ -1,2 +1,3 @@
 <%@ Control Language="C#" AutoEventWireup="false" Explicit="True" Inherits="DotNetNuke.UI.Skins.Skin" %>
 <%@ Register TagPrefix="dnn" TagName="META" Src="~/Admin/Skins/Meta.ascx" %>
+<%@ Register TagPrefix="dnn" Namespace="DotNetNuke.Web.Client.ClientResourceManagement" Assembly="DotNetNuke.Web.Client" %>


### PR DESCRIPTION
## Related to Issue
Resolves #220 

## Description
This resolves an issue with the loading of the popUpSkin.  A missing register for the Client Resource Manager was missing - thus causing the bug.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
