### PR TITLE
Update MainMenu.txt for slight better "target"

### DIFF
--- a/menus/main/MainMenu.txt
+++ b/menus/main/MainMenu.txt
@@ -6,7 +6,7 @@
     <li[?SELECTED] class="active"[/?]>
       
       [?ENABLED]
-        <a href="[=URL]" class="btn btn-primary[?NODE] split[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
+        <a href="[=URL]" class="btn btn-main-shade[?NODE] split[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [?ELSE]    
         <a href="#" class="btn btn-primary[?NODE] single[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [/?]

--- a/menus/main/MainMenu.txt
+++ b/menus/main/MainMenu.txt
@@ -6,9 +6,9 @@
     <li[?SELECTED] class="active"[/?]>
       
       [?ENABLED]
-        <a href="[=URL]" class="btn btn-primary[?NODE] split[/?]" target="[=TARGET]">[=TEXT]</a>
+        <a href="[=URL]" class="btn btn-primary[?NODE] split[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [?ELSE]    
-        <a href="#" class="btn btn-primary[?NODE] single[/?]" target="[=TARGET]">[=TEXT]</a>
+        <a href="#" class="btn btn-primary[?NODE] single[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [/?]
       
       [?NODE]
@@ -23,9 +23,9 @@
     <li class="[?SELECTED] active[/?]">
       
       [?ENABLED]  
-        <a href="[=URL]" [?NODE]class="split"[/?] target="[=TARGET]">[=TEXT]</a>
+        <a href="[=URL]" [?NODE]class="split"[/?][?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [?ELSE]
-        <a href="#" target="[=TARGET]">[=TEXT]</a>
+        <a href="#"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [/?]
       
       [?NODE]

--- a/menus/main/MainMenu.txt
+++ b/menus/main/MainMenu.txt
@@ -8,7 +8,7 @@
       [?ENABLED]
         <a href="[=URL]" class="btn btn-main-shade[?NODE] split[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [?ELSE]    
-        <a href="#" class="btn btn-primary[?NODE] single[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
+        <a href="#" class="btn btn-main-shade[?NODE] single[/?]"[?TARGET] target="[=TARGET]"[/?]>[=TEXT]</a>
       [/?]
       
       [?NODE]


### PR DESCRIPTION
Added the conditional wrapper on each occurrence of target=, this way, for the majority of links that are local and do not open in a new window, you don't end up with menus full of empty target attributes. (e.g. `target=""`).
 
Warning: I did test this. It also looks right. But your mileage may vary. :)

<!--- Provide a general summary of your changes in the Title above -->
## Related to [Issue 243](/nvisionative/nvQuickTheme/issues/243)
Fixes #243 

## Description
added [?TARGET] - [/?] wrappers where needed

## How Has This Been Tested?
Configured a DNN site's menus using the token template before and after the change, results were as expect (after) no empty target attributes.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/653301/96943947-27803000-149f-11eb-92e9-4ab01f3d990b.png)

[x] Bug fix (non-breaking change which fixes an issue)
[?] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
