### PR TITLE
Ensure hidden login is accessible when logged in

### DIFF
--- a/src/scss/components/_login.scss
+++ b/src/scss/components/_login.scss
@@ -121,9 +121,8 @@
 .hiddenLogin {
     bottom: 0;
     display: none;
-    height: 25px;
-    left: 0;
+    height: 30px;
     position: fixed;
     text-indent: -1000px;
-    width: 25px;
+    width: 30px;
 }


### PR DESCRIPTION
## Related to Issue
Resolves #277 

## Description
Removes the `left: 0;` in SCSS to ensure the `hiddenLogin` is accessbile when logged in, and is not behind the PersonaBar.  It also increases the size of the `hiddenLogin` to 30px x 30px (previously 25px x 25px).

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a 😂👍🏼 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
