### PR TITLE
Add starting point for release notes

### DIFF
--- a/themeReleaseNotes.txt
+++ b/themeReleaseNotes.txt
@@ -1,0 +1,12 @@
+<h2>________ Theme</h2>
+<div><em>A custom DNN theme designed and developed for the ________.</em></div>
+<div>&nbsp;</div>
+<h3>Release History</h3>
+<hr />
+<div>&nbsp;</div>
+<div>
+	<h4>Version 1.0.0</h4>
+	<ul>
+		<li style="margin-left:20px;">Initial Release</li>
+	</ul>
+</div>


### PR DESCRIPTION
## Related to Issue
Resolves #278 

## Description
This adds a "template" of sorts to be used for the release notes.  This should help theme creators follow best practices by including release notes with their themes.

## How Has This Been Tested?
Local development environment.

## Screenshots (if appropriate):
n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
