### PR TITLE
Update division signs

### DIFF
--- a/src/scss/mixins/_mixins.scss
+++ b/src/scss/mixins/_mixins.scss
@@ -1,33 +1,33 @@
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, ($num * 0 + 1));
 }
 
 // rem font-size with px fallback
 // usage: @include font-size(16)
 @mixin font-size($sizeValue) {
   font-size: $sizeValue + px;
-  font-size: ($sizeValue / 16) + rem;
+  font-size: math.div($sizeValue, 16) + rem;
 }
 
 // vertical rhythm
 // usage: @include font-baseline(16,24);
 @mixin font-baseline($font-size, $lineheight){
 	font-size: $font-size + px;
-	font-size: ($font-size / $base-font-size ) + rem;
-	line-height: ( $lineheight / $font-size / 1 );
-  margin: 0 0 ( ($lineheight / $font-size * ( 1 / ( $lineheight / $defaultlineheight))) * .5em ) 0; 
+	font-size: math.div($font-size, $base-font-size) + rem;
+	line-height: math.div($lineheight, $font-size);
+  margin: 0 0 ((math.div($lineheight, $font-size) * math.div(1, math.div($lineheight, $defaultlineheight))) * .5em ) 0; 
 }
 
 // Shorthand for media queries at px width and lower
 @mixin mq-max-width( $width-in-px ) {
-  @media only screen and (max-width: ($width-in-px / $base-font-size) * 1em ) {
+  @media only screen and (max-width: (math.div($width-in-px, $base-font-size) * 1em )) {
     @content;
   }
 }
 
 // Shorthand for media queries at px width and higher
 @mixin mq-min-width( $width-in-px ) {
-  @media only screen and (min-width: ($width-in-px / $base-font-size) * 1em ) {
+  @media only screen and (min-width: (math.div($width-in-px, $base-font-size) * 1em )) {
     @content;
   }
 }

--- a/src/scss/mixins/_mixins.scss
+++ b/src/scss/mixins/_mixins.scss
@@ -1,33 +1,33 @@
 @function strip-unit($num) {
-  @return math.div($num, ($num * 0 + 1));
+  @return calc($num / ($num * 0 + 1));
 }
 
 // rem font-size with px fallback
 // usage: @include font-size(16)
 @mixin font-size($sizeValue) {
   font-size: $sizeValue + px;
-  font-size: math.div($sizeValue, 16) + rem;
+  font-size: calc($sizeValue / 16) + rem;
 }
 
 // vertical rhythm
 // usage: @include font-baseline(16,24);
 @mixin font-baseline($font-size, $lineheight){
 	font-size: $font-size + px;
-	font-size: math.div($font-size, $base-font-size) + rem;
-	line-height: math.div($lineheight, $font-size);
-  margin: 0 0 ((math.div($lineheight, $font-size) * math.div(1, math.div($lineheight, $defaultlineheight))) * .5em ) 0; 
+	font-size: calc($font-size / $base-font-size) + rem;
+	line-height: calc($lineheight / $font-size);
+  margin: 0 0 ((calc($lineheight / $font-size) * calc(1 / calc($lineheight / $defaultlineheight))) * .5em ) 0; 
 }
 
 // Shorthand for media queries at px width and lower
 @mixin mq-max-width( $width-in-px ) {
-  @media only screen and (max-width: (math.div($width-in-px, $base-font-size) * 1em )) {
+  @media only screen and (max-width: (calc($width-in-px / $base-font-size) * 1em )) {
     @content;
   }
 }
 
 // Shorthand for media queries at px width and higher
 @mixin mq-min-width( $width-in-px ) {
-  @media only screen and (min-width: (math.div($width-in-px, $base-font-size) * 1em )) {
+  @media only screen and (min-width: (calc($width-in-px / $base-font-size) * 1em )) {
     @content;
   }
 }

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,3 +1,4 @@
+@use 'sass:math';
 @import 'variables/bs-overrides';
 @import 'autoload/autoload';
 @import 'variables/variables';

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -1,4 +1,3 @@
-@use 'sass:math';
 @import 'variables/bs-overrides';
 @import 'autoload/autoload';
 @import 'variables/variables';

--- a/src/scss/variables/_bs-overrides.scss
+++ b/src/scss/variables/_bs-overrides.scss
@@ -35,7 +35,7 @@ $container-max-widths: (
 $spacer:1rem;
 $spacers: (
   0: 0,
-  half: ($spacer / 2),
+  half: math.div($spacer, 2),
   1: $spacer,
   3half: ($spacer * 1.5),
   2: ($spacer * 2),

--- a/src/scss/variables/_bs-overrides.scss
+++ b/src/scss/variables/_bs-overrides.scss
@@ -35,7 +35,7 @@ $container-max-widths: (
 $spacer:1rem;
 $spacers: (
   0: 0,
-  half: math.div($spacer, 2),
+  half: calc($spacer / 2),
   1: $spacer,
   3half: ($spacer * 1.5),
   2: ($spacer * 2),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #299 

## Description
This adds the scss math function which changes the use of division signs to instead use `math.div`. This will get rid of deprecation warnings.

## How Has This Been Tested?
Changed and compiled.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
