### PR TITLE
Replace gulp notify

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -372,6 +372,9 @@ function zipelse() {
     .pipe(replace('dist/', ''))
     .pipe(zip(paths.zipelse.zipfile))
     .pipe(gulp.dest(paths.zipelse.dest))
+    .on('end', function() {
+      log('dist path removed and zipdist temporarily recreated!');
+    })
 }
 
 // git ziptemp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -357,6 +357,9 @@ function zipcontainers() {
   return gulp.src(paths.zipcontainers.src)
     .pipe(zip(paths.zipcontainers.zipfile))
     .pipe(gulp.dest(paths.zipcontainers.dest))
+    .on('end', function() {
+      log('zipcontainers temporarily created!');
+    })
 }
 
 // ZIP everything else

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,7 +121,7 @@ function faFontsInit() {
     .pipe(gulp.dest(paths.faFonts.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'FontAwesome files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,7 +110,7 @@ function fontsInit() {
     .pipe(gulp.dest(paths.fonts.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'font files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -366,6 +366,9 @@ function zipcontainers() {
 function zipelse() {
   return gulp.src(paths.zipelse.src, {base: '.'})
     .pipe(gulp.dest(paths.zipelse.dest))
+    .on('end', function() {
+      log('zipelse temporarily created!');
+    })
     .pipe(replace('dist/', ''))
     .pipe(zip(paths.zipelse.zipfile))
     .pipe(gulp.dest(paths.zipelse.dest))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -132,7 +132,7 @@ function faCssInit() {
     .pipe(gulp.dest(paths.faCss.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'CSS files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -347,6 +347,9 @@ function zipdist() {
   return gulp.src(paths.zipdist.src)
     .pipe(zip(paths.zipdist.zipfile))
     .pipe(gulp.dest(paths.zipdist.dest))
+    .on('end', function() {
+      log('zipdist temporarily created!');
+    })
 }
 
 // ZIP contents of containers folder

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -158,7 +158,7 @@ function normalizeInit() {
   .pipe(gulp.dest(paths.normalize.dest, { sourcemaps: '.' }))
   .on('data', function() { nSrc+=1; })
   .on('end', function() {
-    log(nSrc, 'files distributed!');
+    log(nSrc, 'normalize files distributed!');
   })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ var bs            = require('browser-sync').create(),
     webp          = require('gulp-webp'),
     rename        = require('gulp-rename'),
     uglify        = require('gulp-uglify'),
-    notify        = require('gulp-notify'),
+    log           = require('fancy-log'),
     replace       = require('gulp-replace'),
     zip           = require('gulp-zip'),
     clean         = require('gulp-clean'),
@@ -105,52 +105,77 @@ var paths = {
 /*------------------------------------------------------*/
 // Copy fonts from src/fonts to dist/fonts
 function fontsInit() {
+  var nSrc=0;
   return gulp.src(paths.fonts.src)
     .pipe(gulp.dest(paths.fonts.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'fontsInit'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // Copy fontawesome-free fonts from node_modules to dist/fonts
 function faFontsInit() {
+  var nSrc=0;
   return gulp.src(paths.faFonts.src)
     .pipe(gulp.dest(paths.faFonts.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'faFontsInit'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // Copy fontawesome-free CSS from node_modules to dist/css/fontawesome-free
 function faCssInit() {
+  var nSrc=0;
   return gulp.src(paths.faCss.src)
     .pipe(gulp.dest(paths.faCss.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'faCssInit'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // Copy jquery.slimmenu.min.js from src/assets to dist/js
 function slimMenuInit() {
+  var nSrc=0;
   return gulp.src(paths.slimMenu.src)
     .pipe(gulp.dest(paths.slimMenu.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'slimMenuInit'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // Compile normalize.css from node_modules and copy to dist/js
 function normalizeInit() {
+  var nSrc=0;
   return gulp.src(paths.normalize.src, { sourcemaps: true })
   .pipe(sass({outputStyle: 'compressed'}).on('error', sass.logError))
   .pipe(cleanCSS())
   .pipe(rename({suffix: '.min'}))
   .pipe(autoprefixer())
   .pipe(gulp.dest(paths.normalize.dest, { sourcemaps: '.' }))
-  .pipe(notify({message: '<%= file.relative %> compiled and distributed!', title : 'normalizeInit'}));
+  .on('data', function() { nSrc+=1; })
+  .on('end', function() {
+    log(nSrc, 'files distributed!');
+  })
 }
 
 // Copy bootstrap JS from node_modules to dist/js
 function bsJsInit() {
+  var nSrc=0;
   return gulp.src(paths.bsJs.src)
     .pipe(gulp.dest(paths.bsJs.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'bsJsInit'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // modernizr Init
 function modernizrInit() {
+  var nSrc=0;
   return gulp.src(paths.scripts.src)
     .pipe(modernizr({
       'options': [
@@ -163,7 +188,10 @@ function modernizrInit() {
     .pipe(uglify())
     .pipe(rename({suffix: '-custom.min'}))
     .pipe(gulp.dest(paths.scripts.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'modernizrInit', sound: false}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 /*------------------------------------------------------*/
@@ -176,6 +204,7 @@ function modernizrInit() {
 /*------------------------------------------------------*/
 // Optimize images and copy to dist/images
 function optimize() {
+  var nSrc=0;
   return gulp.src(paths.images.src, {since: gulp.lastRun(images)})
 		.pipe(imagemin([
       imagemin.gifsicle({interlaced: true}),
@@ -192,15 +221,22 @@ function optimize() {
       }
     ))
 		.pipe(gulp.dest(paths.images.dest))
-    .pipe(notify({message: '<%= file.relative %> optimized!', title : 'images'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'images optimized!');
+    })
 }
 
 // Make WebP versions of all images
 function convert() {
+  var nSrc=0;
   return gulp.src(paths.images.src, {since: gulp.lastRun(images)})
     .pipe(webp())
     .pipe(gulp.dest(paths.images.dest))
-    .pipe(notify({message: '<%= file.relative %> converted to webp!', title : 'images'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'webp files created!');
+    })
 }
 
 /*------------------------------------------------------*/
@@ -219,7 +255,9 @@ function styles() {
   .pipe(rename({suffix: '.min'}))
   .pipe(autoprefixer())
   .pipe(gulp.dest(paths.styles.dest, { sourcemaps: '.' }))
-  .pipe(notify({message: '<%= file.relative %> compiled and distributed!', title: 'styles'}));
+  .on('end', function() {
+    log('SCSS compiled, minified, and distributed!');
+  })
 }
 /*------------------------------------------------------*/
 /* END STYLES TASKS ------------------------------------*/
@@ -238,7 +276,9 @@ function scripts() {
     .pipe(gulp.dest(paths.scripts.dest, { sourcemaps: '.' }))
     .pipe(jshint.reporter('default'))
     .pipe(jshint.reporter('fail'))
-    .pipe(notify({ message : '<%= file.relative %> minified!', title : "scripts"}));
+    .on('end', function() {
+      log('JS uglified and distributed!');
+    })
 }
 /*------------------------------------------------------*/
 /* END SCRIPTS TASKS -----------------------------------*/
@@ -250,9 +290,13 @@ function scripts() {
 /*------------------------------------------------------*/
 // Copy containers to proper DNN theme containers folder
 function containers() {
+  var nSrc=0;
   return gulp.src(paths.containers.src)
     .pipe(gulp.dest(paths.containers.dest))
-    .pipe(notify({message: '<%= file.relative %> distributed!', title : 'containers'}));
+    .on('data', function() { nSrc+=1; })
+    .on('end', function() {
+      log(nSrc, 'files distributed!');
+    })
 }
 
 // Update manifest.dnn
@@ -270,7 +314,9 @@ function manifest() {
     .pipe(replace(/(\\Skins\\)(.*?)(?=\\)/g, '\\Skins\\'+project))
     .pipe(replace(/(\\Containers\\)(.*?)(?=\\)/g, '\\Containers\\'+project))
     .pipe(gulp.dest(paths.manifest.dest))
-    .pipe(notify({message: '<%= file.relative %> updated!', title : 'manifest'}));
+    .on('end', function() {
+      log('DNN manifest updated!');
+    })
 }
 /*------------------------------------------------------*/
 /* END DNN TASKS ---------------------------------------*/
@@ -284,7 +330,9 @@ function manifest() {
 function cleandist() {
   return gulp.src(paths.cleandist.src, { allowEmpty: true })
     .pipe(clean())
-    .pipe(notify({message: 'dist folder cleaned up!', title : 'cleandist'}));
+    .on('end', function() {
+      log('dist folder cleaned up!');
+    })
 }
 /*------------------------------------------------------*/
 /* END MAINTENANCE TASKS -------------------------------*/
@@ -299,7 +347,6 @@ function zipdist() {
   return gulp.src(paths.zipdist.src)
     .pipe(zip(paths.zipdist.zipfile))
     .pipe(gulp.dest(paths.zipdist.dest))
-    .pipe(notify({message: '<%= file.relative %> temporarily created!', title : 'zipdist'}));
 }
 
 // ZIP contents of containers folder
@@ -307,18 +354,15 @@ function zipcontainers() {
   return gulp.src(paths.zipcontainers.src)
     .pipe(zip(paths.zipcontainers.zipfile))
     .pipe(gulp.dest(paths.zipcontainers.dest))
-    .pipe(notify({message: '<%= file.relative %> temporarily created!', title : 'zipcontainers'}));
 }
 
 // ZIP everything else
 function zipelse() {
   return gulp.src(paths.zipelse.src, {base: '.'})
     .pipe(gulp.dest(paths.zipelse.dest))
-    .pipe(notify({message: '<%= file.relative %> temporarily created!', title : 'zipcontainers'}))
     .pipe(replace('dist/', ''))
     .pipe(zip(paths.zipelse.zipfile))
     .pipe(gulp.dest(paths.zipelse.dest))
-    .pipe(notify({message: '<%= file.relative %> temporarily created!', title : 'zipcontainers'}));
 }
 
 // git ziptemp
@@ -329,14 +373,18 @@ function zippackage() {
   return gulp.src(paths.zippackage.src)
     .pipe(zip(paths.zippackage.zipfile))
     .pipe(gulp.dest(paths.zippackage.dest))
-    .pipe(notify({message: '<%= file.relative %> created!', title : 'zippackage'}));
+    .on('end', function() {
+      log('Theme install package created!');
+    })
 }
 
 // Clean temp folder
 function cleantemp() {
   return gulp.src(paths.cleantemp.src)
     .pipe(clean())
-    .pipe(notify({message: 'temp folder cleaned up!', title : 'cleantemp'}));
+    .on('end', function() {
+      log('temp folder cleaned up!');
+    })
 }
 /*------------------------------------------------------*/
 /* END PACKAGING TASKS ---------------------------------*/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -143,7 +143,7 @@ function slimMenuInit() {
     .pipe(gulp.dest(paths.slimMenu.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'slimMenu files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -295,7 +295,7 @@ function containers() {
     .pipe(gulp.dest(paths.containers.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'container files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,7 @@ function bsJsInit() {
     .pipe(gulp.dest(paths.bsJs.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'Bootstrap JS files distributed!');
     })
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -190,7 +190,7 @@ function modernizrInit() {
     .pipe(gulp.dest(paths.scripts.dest))
     .on('data', function() { nSrc+=1; })
     .on('end', function() {
-      log(nSrc, 'files distributed!');
+      log(nSrc, 'modernizr files distributed!');
     })
 }
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "browser-sync": "^2.27.9",
+    "fancy-log": "^2.0.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^8.0.0",
     "gulp-clean": "^0.4.0",
@@ -20,7 +21,6 @@
     "gulp-imagemin": "^7.1.0",
     "gulp-jshint": "^2.1.0",
     "gulp-modernizr": "^4.0.3",
-    "gulp-notify": "^4.0.0",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.1.3",
     "gulp-sass": "^5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -124,11 +124,6 @@ ansi-colors@^1.0.1:
   dependencies:
     ansi-wrap "^0.1.0"
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
 ansi-cyan@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ansi-cyan/-/ansi-cyan-0.1.1.tgz#538ae528af8982f28ae30d86f2f17456d2609873"
@@ -1833,6 +1828,13 @@ fancy-log@^1.3.2, fancy-log@^1.3.3:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
+fancy-log@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-2.0.0.tgz#cad207b8396d69ae4796d74d17dff5f68b2f7343"
+  integrity sha512-9CzxZbACXMUXW13tS0tI8XsGGmxWzO2DmYrGuBJOJ8k8q2K7hwfJA5qHjuPPe8wtsco33YR9wc+Rlr5wYFvhSA==
+  dependencies:
+    color-support "^1.1.3"
+
 fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2375,11 +2377,6 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-growly@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
-  integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
 gulp-autoprefixer@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/gulp-autoprefixer/-/gulp-autoprefixer-8.0.0.tgz#ee2413d6cb9f7cc2f01b7d9835b46e58e326b88d"
@@ -2475,19 +2472,6 @@ gulp-modernizr@^4.0.3:
     plugin-error "^1.0.1"
     through2 "^4.0.2"
     vinyl "^2.2.1"
-
-gulp-notify@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gulp-notify/-/gulp-notify-4.0.0.tgz#768a1b0b0224e882fa828f27e98e33fcebea7b49"
-  integrity sha512-0cdDvZkHVqu4tqrcOI/jL5YdxYEIPQ7+p3YxnO48w5hhPSisvogZ887qL+fpYItg9m4MUhJ5Se8p8xGy3uJESA==
-  dependencies:
-    ansi-colors "^4.1.1"
-    fancy-log "^1.3.3"
-    lodash.template "^4.5.0"
-    node-notifier "^9.0.1"
-    node.extend "^2.0.2"
-    plugin-error "^1.0.1"
-    through2 "^4.0.2"
 
 gulp-rename@^2.0.0:
   version "2.0.0"
@@ -2989,11 +2973,6 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
 
-is-docker@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
-  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
-
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -3202,18 +3181,6 @@ is-wsl@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
-
-is-wsl@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
-  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
-  dependencies:
-    is-docker "^2.0.0"
-
-is@^3.2.1:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/is/-/is-3.3.0.tgz#61cff6dd3c4193db94a3d62582072b44e5645d79"
-  integrity sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg==
 
 isarray@0.0.1:
   version "0.0.1"
@@ -3425,11 +3392,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash._reinterpolate@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
-  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
-
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
@@ -3454,21 +3416,6 @@ lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.template@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
-  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
-    lodash.templatesettings "^4.0.0"
-
-lodash.templatesettings@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
-  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
-  dependencies:
-    lodash._reinterpolate "^3.0.0"
 
 lodash@^4.12.0:
   version "4.17.19"
@@ -3528,13 +3475,6 @@ lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"
@@ -3823,30 +3763,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-notifier@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-9.0.1.tgz#cea837f4c5e733936c7b9005e6545cea825d1af4"
-  integrity sha512-fPNFIp2hF/Dq7qLDzSg4vZ0J4e9v60gJR+Qx7RbjbWqzPDdEqeVpEx5CFeDAELIl+A/woaaNn1fQ5nEVerMxJg==
-  dependencies:
-    growly "^1.3.0"
-    is-wsl "^2.2.0"
-    semver "^7.3.2"
-    shellwords "^0.1.1"
-    uuid "^8.3.0"
-    which "^2.0.2"
-
 node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
-
-node.extend@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/node.extend/-/node.extend-2.0.2.tgz#b4404525494acc99740f3703c496b7d5182cc6cc"
-  integrity sha512-pDT4Dchl94/+kkgdwyS2PauDFjZG0Hk0IcHIB+LkW27HLDtdoeMxHTxZh39DYbPP8UflWXWj9JcdDozF+YDOpQ==
-  dependencies:
-    has "^1.0.3"
-    is "^3.2.1"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -4851,13 +4771,6 @@ semver@^6.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
 send@0.16.2:
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/send/-/send-0.16.2.tgz#6ecca1e0f8c156d141597559848df64730a6bbc1"
@@ -4953,11 +4866,6 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
-
-shellwords@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
-  integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
 signal-exit@^3.0.0, signal-exit@^3.0.3:
   version "3.0.3"
@@ -5719,11 +5627,6 @@ uuid@^3.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 v8flags@^3.0.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.1.3.tgz#fc9dc23521ca20c5433f81cc4eb9b3033bb105d8"
@@ -5844,7 +5747,7 @@ which@^1.2.14, which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1, which@^2.0.2:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -5916,11 +5819,6 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@>=5.0.0-security.0, yargs-parser@^20.2.2:
   version "20.2.9"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Related to Issue
Fixes #305 

## Description
I replaced `gulp-notify` with `fancy-log`. This simpler solution doesn't interact with windows notifications, which resolves problems created by such. Instead of showing every file being distributed, it shows how many files for batch jobs. For single resolution jobs, it shows confirmation that it has been completed as expected.

## How Has This Been Tested?
I have ran both `gulp` and `gulp package` successfully and without it hanging. The logs are clear and work correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
