### PR TITLE
Refactor desktop RazorMenu to remove duplicate code

### DIFF
--- a/menus/desktop/RazorMenu.cshtml
+++ b/menus/desktop/RazorMenu.cshtml
@@ -31,34 +31,7 @@
             @if (hasChildren)
             {
                 <ul>
-                    @RenderNestedPages(page.Children)
-                </ul>
-            }
-        </li>
-    }
-}
-
-@helper RenderNestedPages(IEnumerable<MenuNode> pages)
-{
-    foreach (var page in pages)
-    {
-        var hasChildren = page.HasChildren();
-        var attrTarget = !string.IsNullOrEmpty(page.Target) ? ("target=\"" + page.Target + "\"") :string.Empty;
-
-        <li class="@(page.Selected ? "selected" : string.Empty)">
-            @if (page.Enabled)
-            {
-                <a href="@page.Url" @attrTarget>@page.Text</a>
-            }
-            else
-            {
-                <a href="javascript:void(0);" @attrTarget>@page.Text</a>
-            }
-
-            @if (hasChildren)
-            {
-                <ul>
-                    @RenderNestedPages(page.Children)
+                    @RenderPages(page.Children)
                 </ul>
             }
         </li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nvquicktheme",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "Barebones Bootstrap 5 DNN Theme",
   "main": "gulpfile.js",
   "author": "nvisionative",

--- a/src/js/customMenu.js
+++ b/src/js/customMenu.js
@@ -1,7 +1,5 @@
 /*jshint esversion: 6 */
 
-console.clear();
-
 const navExpand = [].slice.call(document.querySelectorAll('.nav-expand'));
 
 navExpand.forEach(item => {


### PR DESCRIPTION
## Related to Issue
Fixes #328 

## Description
* Removes duplicate code in `RazorMenu.cshtml` for desktop. 
* Updates version of `nvQuickTheme` in preparation of the `3.0.0` release.
* Removes rogue `console.clear()` from `customMenu.js`.

## How Has This Been Tested?
Tested locally in DNN instance.  Menu renders perfectly.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
