### PR TITLE
Update `koi.json` to indicate Bootstrap 5 instead of Bootstrap 4

### DIFF
--- a/koi.json
+++ b/koi.json
@@ -4,6 +4,6 @@
 		"discoverMore": "https://connect-koi.net/"
 	},
 	"default": {
-		"cssFramework": "bs4"
+		"cssFramework": "bs5"
 	}
 }

--- a/manifest.dnn
+++ b/manifest.dnn
@@ -1,6 +1,6 @@
 <dotnetnuke type="Package" version="9.0">
   <packages>
-    <package name="nvisionative.nvQuickTheme" type="Skin" version="3.1.0">
+    <package name="nvisionative.nvQuickTheme" type="Skin" version="3.1.1">
       <friendlyName>nvQuickTheme</friendlyName>
       <description>A DNN Theme Dev Framework</description>
       <iconFile>MyIcon.png</iconFile>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nvquicktheme",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Barebones Bootstrap 5 DNN Theme",
   "main": "gulpfile.js",
   "author": "nvisionative",

--- a/project-details.json
+++ b/project-details.json
@@ -1,6 +1,6 @@
 {
 	"project": "nvQuickTheme",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"author": "TK Sheppard &amp; David Poindexter",
 	"company": "nvisionative",
 	"url": "www.nvquicktheme.com",


### PR DESCRIPTION
## Related to Issue
Resolves #365 

## Description
This PR updates `koi.json` to properly indicate the theme's usage of Bootstrap 5 (previously Bootstrap 4).

## How Has This Been Tested?
Local development environment

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
